### PR TITLE
Override the _exit syscall to return correct val

### DIFF
--- a/mips_syscall.H
+++ b/mips_syscall.H
@@ -35,6 +35,8 @@ public:
   void set_int(int argn, int val);
   void return_from_syscall();
   void set_prog_args(int argc, char **argv);
+
+  void _exit();
 };
 
 #endif

--- a/mips_syscall.cpp
+++ b/mips_syscall.cpp
@@ -121,5 +121,9 @@ void mips_syscall::set_prog_args(int argc, char **argv)
   procNumber ++;
 }
 
-
+void mips_syscall::_exit() {
+    DEBUG_SYSCALL("_exit");
+    int ac_exit_status = RB[2]; //v0
+    ref.stop(ac_exit_status);
+}
 


### PR DESCRIPTION
The default implementation of the _exit syscall (ac_syscall.H) returns
the value from the `get_int(0)`. The `get_int` in MIPS model returns
RB[argn+4]. So, the register R4 should contain the return value.
But the MIPS cross-compiler is putting the return value in R2. So,
I overrided the _exit syscall to return the R2 value.
