### PR TITLE
Explicit ignore expression result

### DIFF
--- a/mips_isa.cpp
+++ b/mips_isa.cpp
@@ -585,7 +585,7 @@ void ac_behavior( jr )
   // Jump to the address stored on the register reg[RS]
   // It must also flush the instructions that were loaded into the pipeline
 #ifndef NO_NEED_PC_UPDATE
-  npc = RB[rs], 1;
+  npc = RB[rs], (void) 1;
 #endif 
   dbg_printf("Target = %#x\n", RB[rs]);
 };
@@ -598,7 +598,7 @@ void ac_behavior( jalr )
   // jump to the address given by [rs]
 
 #ifndef NO_NEED_PC_UPDATE
-  npc = RB[rs], 1;
+  npc = RB[rs], (void) 1;
 #endif 
   dbg_printf("Target = %#x\n", RB[rs]);
 
@@ -638,7 +638,7 @@ void ac_behavior( blez )
   dbg_printf("blez r%d, %d\n", rs, imm & 0xFFFF);
   if( (RB[rs] == 0 ) || (RB[rs]&0x80000000 ) ){
 #ifndef NO_NEED_PC_UPDATE
-    npc = ac_pc + (imm<<2), 1;
+    npc = ac_pc + (imm<<2), (void) 1;
 #endif 
     dbg_printf("Taken to %#x\n", ac_pc + (imm<<2));
   }	


### PR DESCRIPTION
Ignore the result of the expression "1" prepending "(void)".
