### PR TITLE
Correcting instructions bc1tl, negs and negd

### DIFF
--- a/mips_isa.ac
+++ b/mips_isa.ac
@@ -524,7 +524,7 @@ AC_ISA(mips){
     bc1t.set_asm("bc1t %exp(pcrel)", imm);
     bc1t.set_decoder(op=0x11, rs=0x08, rt=0x01);
 
-    bc1tl.set_asm("bc1t %exp(pcrel)", imm);
+    bc1tl.set_asm("bc1tl %exp(pcrel)", imm);
     bc1tl.set_decoder(op=0x11, rs=0x08, rt=0x03);
 
     bc1f.set_asm("bc1f %exp(pcrel)", imm);

--- a/mips_isa.cpp
+++ b/mips_isa.cpp
@@ -423,7 +423,7 @@ void ac_behavior( mtc1 )
 void ac_behavior( negd )
 {
   dbg_printf("neg.d %%f%d, %%f%d\n", shamt, rd);
-  double res = - load_double(rt);
+  double res = - load_double(rd);
   save_double(res, shamt);
   dbg_printf("Result = %lf\n", res);
 }
@@ -431,7 +431,7 @@ void ac_behavior( negd )
 void ac_behavior( negs )
 {
   dbg_printf("neg.s %%f%d, %%f%d\n", shamt, rd);
-  float res = - load_float(rt);
+  float res = - load_float(rd);
   save_float(res, shamt);
   dbg_printf("Result = %f\n", res);
 }


### PR DESCRIPTION
Instruction bc1tl: Corrected asm.
Instructions negs and negd: Operand should be read from rd instead of rt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/archc/mips/7)
<!-- Reviewable:end -->
